### PR TITLE
Firestore emulator infrastructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,9 @@
         "react-scripts": "4.0.3",
         "styled-components": "^5.3.1",
         "web-vitals": "^1.0.1"
+      },
+      "devDependencies": {
+        "cross-env": "^7.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7082,6 +7085,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -26700,6 +26721,15 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "emulator-build": "cross-env REACT_APP_USE_FIRESTORE_EMULATOR=true react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -41,5 +42,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.3"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -51,8 +51,15 @@ getAnalytics(firebaseApp);
 const db = initializeDB(firebaseApp);
 
 function initializeDB(firebaseApp) {  
-  const isProduction = true; // TODO: Use an environment variable for this
-  if (isProduction) {
+    
+  const isProduction = process.env.NODE_ENV === "production";
+  // The Firebase hosting emulator uses the production code build.  But we want our code
+  //  to connect to the Firestore emulator when we're running this locally.  This variable
+  //  gives us a way to force the code to connect to the Firestore emulator even when the
+  //  NODE_ENV is set to production.
+  const forceUseFirestoreEmulator = process.env.REACT_APP_USE_FIRESTORE_EMULATOR;
+
+  if (isProduction && !forceUseFirestoreEmulator) {
     return getFirestore(firebaseApp);
   }
   else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4393,6 +4393,13 @@
     "safe-buffer" "^5.0.1"
     "sha.js" "^2.4.8"
 
+"cross-env@^7.0.3":
+  "integrity" "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw=="
+  "resolved" "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz"
+  "version" "7.0.3"
+  dependencies:
+    "cross-spawn" "^7.0.1"
+
 "cross-spawn@^6.0.0":
   "integrity" "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ=="
   "resolved" "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz"
@@ -4404,7 +4411,7 @@
     "shebang-command" "^1.2.0"
     "which" "^1.2.9"
 
-"cross-spawn@^7.0.0", "cross-spawn@^7.0.2", "cross-spawn@7.0.3":
+"cross-spawn@^7.0.0", "cross-spawn@^7.0.1", "cross-spawn@^7.0.2", "cross-spawn@7.0.3":
   "integrity" "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w=="
   "resolved" "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz"
   "version" "7.0.3"


### PR DESCRIPTION
Added infrastructure to force the app to connect to the Firestore emulator when the prod build is used locally.  This is needed in order for the hosting-emulated site to connect to the emulated Firestore instance when run locally.

NOTE:  I also have a second solution that is currently not getting checked-into source control b/c CRA listed it in `.gitignore`:  The `.env.production.local` file approach.

See [this Tweet thread](https://twitter.com/jasonkylefrank/status/1441510489775906817) for info about these 2 approaches.